### PR TITLE
extract filter to separate KamonFilter for use in Play with compile-time DI

### DIFF
--- a/kamon-play-2.5.x/src/main/scala/kamon/play/KamonFilter.scala
+++ b/kamon-play-2.5.x/src/main/scala/kamon/play/KamonFilter.scala
@@ -1,0 +1,31 @@
+package kamon.play
+
+import akka.util.ByteString
+import kamon.trace.Tracer
+import kamon.util.SameThreadExecutionContext
+import play.api.libs.streams.Accumulator
+import play.api.mvc.{ EssentialAction, EssentialFilter, RequestHeader, Result }
+
+class KamonFilter extends EssentialFilter {
+
+  override def apply(next: EssentialAction): EssentialAction = new EssentialAction {
+    override def apply(requestHeader: RequestHeader): Accumulator[ByteString, Result] = {
+
+      def onResult(result: Result): Result = {
+        Tracer.currentContext.collect { ctx ⇒
+          ctx.finish()
+          PlayExtension.httpServerMetrics.recordResponse(ctx.name, result.header.status.toString)
+          if (PlayExtension.includeTraceToken) result.withHeaders(PlayExtension.traceTokenHeaderName -> ctx.token)
+          else result
+
+        } getOrElse result
+      }
+
+      //override the current trace name
+      Tracer.currentContext.rename(PlayExtension.generateTraceName(requestHeader))
+      val nextAccumulator = next.apply(requestHeader)
+      nextAccumulator.map(onResult)(SameThreadExecutionContext)
+    }
+  }
+
+}

--- a/kamon-play-2.5.x/src/main/scala/kamon/play/instrumentation/RequestInstrumentation.scala
+++ b/kamon-play-2.5.x/src/main/scala/kamon/play/instrumentation/RequestInstrumentation.scala
@@ -17,7 +17,7 @@ package kamon.play.instrumentation
 
 import akka.util.ByteString
 import kamon.Kamon.tracer
-import kamon.play.PlayExtension
+import kamon.play.{ KamonFilter, PlayExtension }
 import kamon.trace._
 import kamon.util.SameThreadExecutionContext
 import org.aspectj.lang.ProceedingJoinPoint
@@ -29,27 +29,7 @@ import play.api.mvc.{ EssentialFilter, _ }
 @Aspect
 class RequestInstrumentation {
 
-  private val filter: EssentialFilter = new EssentialFilter {
-    override def apply(next: EssentialAction): EssentialAction = new EssentialAction {
-      override def apply(requestHeader: RequestHeader): Accumulator[ByteString, Result] = {
-
-        def onResult(result: Result): Result = {
-          Tracer.currentContext.collect { ctx ⇒
-            ctx.finish()
-            PlayExtension.httpServerMetrics.recordResponse(ctx.name, result.header.status.toString)
-            if (PlayExtension.includeTraceToken) result.withHeaders(PlayExtension.traceTokenHeaderName -> ctx.token)
-            else result
-
-          } getOrElse result
-        }
-
-        //override the current trace name
-        Tracer.currentContext.rename(PlayExtension.generateTraceName(requestHeader))
-        val nextAccumulator = next.apply(requestHeader)
-        nextAccumulator.map(onResult)(SameThreadExecutionContext)
-      }
-    }
-  }
+  private lazy val filter: EssentialFilter = new KamonFilter()
 
   @DeclareMixin("play.api.mvc.RequestHeader+")
   def mixinContextAwareToRequestHeader: TraceContextAware = TraceContextAware.default


### PR DESCRIPTION
When using compile-time DI in Play you have to manually configure Play's filters and the instrumented method play.api.http.HttpFilters.filters(..) is never called.
By extracting the filter to a separate class, it becomes very easy to instantiate the KamonFilter and add it to the filters manually.

BTW, when will you contribute this upstream?
